### PR TITLE
#221: The place order button text will change for PayPal

### DIFF
--- a/AtlasUI/AtlasUI/CheckoutSummaryActionsHandler.swift
+++ b/AtlasUI/AtlasUI/CheckoutSummaryActionsHandler.swift
@@ -55,6 +55,7 @@ extension CheckoutSummaryActionsHandler {
                 self.viewController.userMessage.show(error: error)
             case .success (let order):
                 self.handleOrderConfirmation(order)
+                self.viewController.loaderView.hide()
             }
         }
     }

--- a/AtlasUI/AtlasUI/CheckoutSummaryFooterStackView.swift
+++ b/AtlasUI/AtlasUI/CheckoutSummaryFooterStackView.swift
@@ -42,7 +42,10 @@ extension CheckoutSummaryFooterStackView: UIDataBuilder {
     func configureData(viewModel: T) {
         footerLabel.text = viewModel.loc("CheckoutSummaryViewController.terms")
         footerLabel.hidden = !viewModel.viewState.showFooterLabel
-        submitButton.setTitle(viewModel.loc(viewModel.checkoutViewModel.submitButtonTitle), forState: .Normal)
+
+        let isPaypal = viewModel.checkoutViewModel.checkout?.payment.selected?.isPaypal() ?? false
+
+        submitButton.setTitle(viewModel.loc(viewModel.viewState.submitButtonTitle(isPaypal)), forState: .Normal)
         submitButton.backgroundColor = viewModel.viewState.submitButtonBackgroundColor
     }
 

--- a/AtlasUI/AtlasUI/CheckoutViewModel.swift
+++ b/AtlasUI/AtlasUI/CheckoutViewModel.swift
@@ -45,18 +45,6 @@ extension CheckoutViewModel {
         return selectedBillingAddress?.fullContactPostalAddress ?? localizer.loc("No Billing Address")
     }
 
-    var submitButtonTitle: String {
-        switch self.checkoutViewState {
-            case .NotLoggedIn: return "Zalando.Checkout"
-            case .CheckoutIncomplete, .LoggedIn:
-                if let paymentMethod = checkout?.payment.selected where paymentMethod.isPaypal() {
-                    return "order.place.paypal"
-                }
-                return "order.place"
-            case .OrderPlaced: return "navigation.back.shop"
-        }
-    }
-
     var isPaymentSelected: Bool {
         return customer != nil && selectedPaymentMethod != nil
     }

--- a/AtlasUI/AtlasUI/CheckoutViewState.swift
+++ b/AtlasUI/AtlasUI/CheckoutViewState.swift
@@ -54,6 +54,15 @@ enum CheckoutViewState {
         }
     }
 
+    func submitButtonTitle(isPaypal: Bool) -> String {
+        switch self {
+        case .NotLoggedIn: return "Zalando.Checkout"
+        case .CheckoutIncomplete, .LoggedIn:
+            return isPaypal ? "order.place.paypal" : "order.place"
+        case .OrderPlaced: return "navigation.back.shop"
+        }
+    }
+
     func hideBackButton(hasSingleUnit: Bool) -> Bool {
         guard !hasSingleUnit else { return true }
         switch self {


### PR DESCRIPTION
Previous fix was wrong: I moved text label handling to the CheckoutViewState. Back payment also button fixed.