### PR TITLE
#270: crash with weak viewController fixed

### DIFF
--- a/AtlasUI/AtlasUI/CheckoutSummaryActionsHandler.swift
+++ b/AtlasUI/AtlasUI/CheckoutSummaryActionsHandler.swift
@@ -7,7 +7,7 @@ import AtlasSDK
 
 struct CheckoutSummaryActionsHandler {
 
-    internal unowned let viewController: CheckoutSummaryViewController
+    internal weak var viewController: CheckoutSummaryViewController?
 
 }
 
@@ -26,20 +26,21 @@ extension Checkout {
 extension CheckoutSummaryActionsHandler {
 
     internal func handleBuyAction() {
-        guard let checkout = viewController.checkoutViewModel.checkout else { return }
+        guard let strongViewController = self.viewController else { return }
+        guard let checkout = strongViewController.checkoutViewModel.checkout else { return }
 
-        viewController.showLoader()
-        if checkout.hasSameAddress(like: viewController.checkoutViewModel) {
+        strongViewController.showLoader()
+        if checkout.hasSameAddress(like: strongViewController.checkoutViewModel) {
             return createOrder(checkout.id)
         }
 
-        let updateCheckoutRequest = UpdateCheckoutRequest(checkoutViewModel: viewController.checkoutViewModel)
+        let updateCheckoutRequest = UpdateCheckoutRequest(checkoutViewModel: strongViewController.checkoutViewModel)
 
-        viewController.checkout.client.updateCheckout(checkout.id, updateCheckoutRequest: updateCheckoutRequest) { result in
+        strongViewController.checkout.client.updateCheckout(checkout.id, updateCheckoutRequest: updateCheckoutRequest) { result in
             switch result {
             case .failure(let error):
-                self.viewController.userMessage.show(error: error)
-                self.viewController.hideLoader()
+                strongViewController.userMessage.show(error: error)
+                strongViewController.hideLoader()
             case .success(let checkout):
                 self.createOrder(checkout.id)
             }
@@ -47,14 +48,16 @@ extension CheckoutSummaryActionsHandler {
     }
 
     internal func createOrder(checkoutId: String) {
-        viewController.checkout.client.createOrder(checkoutId) { result in
+        guard let strongViewController = self.viewController else { return }
+
+        strongViewController.checkout.client.createOrder(checkoutId) { result in
             switch result {
             case .failure(let error):
-                self.viewController.userMessage.show(error: error)
-                self.viewController.hideLoader()
+                strongViewController.userMessage.show(error: error)
+                strongViewController.hideLoader()
             case .success (let order):
                 self.handleOrderConfirmation(order)
-                self.viewController.hideLoader()
+                strongViewController.hideLoader()
             }
         }
     }
@@ -64,12 +67,14 @@ extension CheckoutSummaryActionsHandler {
 extension CheckoutSummaryActionsHandler {
 
     internal func loadCustomerData() {
-        viewController.checkout.client.customer { result in
+        guard let strongViewController = self.viewController else { return }
+
+        strongViewController.checkout.client.customer { result in
 
             switch result {
             case .failure(let error):
                 Async.main {
-                    self.viewController.userMessage.show(error: error)
+                    strongViewController.userMessage.show(error: error)
                 }
             case .success(let customer):
                 self.generateCheckout(customer)
@@ -79,19 +84,21 @@ extension CheckoutSummaryActionsHandler {
     }
 
     private func generateCheckout(customer: Customer) {
-        viewController.showLoader()
-        viewController.checkout.prepareCheckoutViewModel(viewController.checkoutViewModel.selectedArticleUnit,
-            checkoutViewModel: viewController.checkoutViewModel) { result in
-                self.viewController.hideLoader()
+        guard let strongViewController = self.viewController else { return }
+
+        strongViewController.showLoader()
+        strongViewController.checkout.prepareCheckoutViewModel(strongViewController.checkoutViewModel.selectedArticleUnit,
+            checkoutViewModel: strongViewController.checkoutViewModel) { result in
+                strongViewController.hideLoader()
                 switch result {
                 case .failure(let error):
-                    self.viewController.dismissViewControllerAnimated(true) {
-                        self.viewController.userMessage.show(error: error)
+                    strongViewController.dismissViewControllerAnimated(true) {
+                        strongViewController.userMessage.show(error: error)
                     }
                 case .success(var checkoutViewModel):
                     checkoutViewModel.customer = customer
-                    self.viewController.checkoutViewModel = checkoutViewModel
-                    self.viewController.viewState = checkoutViewModel.checkoutViewState
+                    strongViewController.checkoutViewModel = checkoutViewModel
+                    strongViewController.viewState = checkoutViewModel.checkoutViewState
                 }
         }
     }
@@ -101,53 +108,59 @@ extension CheckoutSummaryActionsHandler {
 extension CheckoutSummaryActionsHandler {
 
     internal func showPaymentSelectionScreen() {
+        guard let strongViewController = self.viewController else { return }
         guard Atlas.isUserLoggedIn() else { return loadCustomerData() }
-        guard let paymentURL = viewController.checkoutViewModel.checkout?.payment.selectionPageUrl else { return }
+        guard let paymentURL = strongViewController.checkoutViewModel.checkout?.payment.selectionPageUrl else { return }
 
-        let paymentSelectionViewController = PaymentSelectionViewController(paymentSelectionURL: paymentURL)
-        paymentSelectionViewController.paymentCompletion = { result in
+        let paymentSelectionstrongViewController = PaymentSelectionViewController(paymentSelectionURL: paymentURL)
+        paymentSelectionstrongViewController.paymentCompletion = { result in
             switch result {
             case .success:
                 self.loadCustomerData()
             case .failure(let error):
-                self.viewController.userMessage.show(error: error)
+                strongViewController.userMessage.show(error: error)
             }
         }
-        viewController.showViewController(paymentSelectionViewController, sender: viewController)
+        strongViewController.showViewController(paymentSelectionstrongViewController, sender: strongViewController)
     }
 
     internal func showShippingAddressSelectionScreen() {
+        guard let strongViewController = self.viewController else { return }
         guard Atlas.isUserLoggedIn() else { return loadCustomerData() }
-        let addressSelectionViewController = AddressPickerViewController(checkout: viewController.checkout,
+        let addressSelectionstrongViewController = AddressPickerViewController(checkout: strongViewController.checkout,
             addressType: .shipping, addressSelectionCompletion: pickedAddressCompletion)
-        addressSelectionViewController.selectedAddress = viewController.checkoutViewModel.selectedShippingAddress
-        viewController.showViewController(addressSelectionViewController, sender: viewController)
+        addressSelectionstrongViewController.selectedAddress = strongViewController.checkoutViewModel.selectedShippingAddress
+        strongViewController.showViewController(addressSelectionstrongViewController, sender: strongViewController)
     }
 
     internal func showBillingAddressSelectionScreen() {
+        guard let strongViewController = self.viewController else { return }
         guard Atlas.isUserLoggedIn() else { return loadCustomerData() }
-        let addressSelectionViewController = AddressPickerViewController(checkout: viewController.checkout, addressType: .billing,
-            addressSelectionCompletion: pickedAddressCompletion)
-        addressSelectionViewController.selectedAddress = viewController.checkoutViewModel.selectedBillingAddress
-        viewController.showViewController(addressSelectionViewController, sender: viewController)
+        let addressSelectionstrongViewController = AddressPickerViewController(checkout: strongViewController.checkout,
+                                                                               addressType: .billing,
+                                                                               addressSelectionCompletion: pickedAddressCompletion)
+        addressSelectionstrongViewController.selectedAddress = strongViewController.checkoutViewModel.selectedBillingAddress
+        strongViewController.showViewController(addressSelectionstrongViewController, sender: strongViewController)
     }
 
     internal func handleOrderConfirmation(order: Order) {
+        guard let strongViewController = self.viewController else { return }
+
         guard let paymentURL = order.externalPaymentUrl else {
-            self.viewController.viewState = .OrderPlaced
+            strongViewController.viewState = .OrderPlaced
             return
         }
 
-        let paymentSelectionViewController = PaymentSelectionViewController(paymentSelectionURL: paymentURL)
-        paymentSelectionViewController.paymentCompletion = { result in
+        let paymentSelectionstrongViewController = PaymentSelectionViewController(paymentSelectionURL: paymentURL)
+        paymentSelectionstrongViewController.paymentCompletion = { result in
             switch result {
             case .success:
-                self.viewController.viewState = .OrderPlaced
+                strongViewController.viewState = .OrderPlaced
             case .failure(let error):
-                self.viewController.userMessage.show(error: error)
+                strongViewController.userMessage.show(error: error)
             }
         }
-        viewController.showViewController(paymentSelectionViewController, sender: viewController)
+        strongViewController.showViewController(paymentSelectionstrongViewController, sender: strongViewController)
     }
 
 }
@@ -155,38 +168,39 @@ extension CheckoutSummaryActionsHandler {
 extension CheckoutSummaryActionsHandler {
     func pickedAddressCompletion(pickedAddress address: EquatableAddress?,
         forAddressType addressType: AddressType) {
+            guard let strongViewController = self.viewController else { return }
 
-            viewController.navigationController?.popViewControllerAnimated(true)
+            strongViewController.navigationController?.popViewControllerAnimated(true)
 
             switch addressType {
             case AddressType.billing:
-                viewController.checkoutViewModel.selectedBillingAddress = address
+                strongViewController.checkoutViewModel.selectedBillingAddress = address
             case AddressType.shipping:
-                viewController.checkoutViewModel.selectedShippingAddress = address
+                strongViewController.checkoutViewModel.selectedShippingAddress = address
             }
             if address == nil {
-                viewController.checkoutViewModel.checkout = nil
+                strongViewController.checkoutViewModel.checkout = nil
             }
-            viewController.hideLoader()
-            viewController.rootStackView.configureData(viewController)
-            viewController.refreshViewData()
+            strongViewController.hideLoader()
+            strongViewController.rootStackView.configureData(strongViewController)
+            strongViewController.refreshViewData()
 
-            guard viewController.checkoutViewModel.isReadyToCreateCheckout == true else { return }
-            viewController.showLoader()
+            guard strongViewController.checkoutViewModel.isReadyToCreateCheckout == true else { return }
+            strongViewController.showLoader()
 
-            viewController.checkout.prepareCheckoutViewModel(viewController.checkoutViewModel.selectedArticleUnit,
-                checkoutViewModel: viewController.checkoutViewModel) { result in
-                    self.viewController.hideLoader()
+            strongViewController.checkout.prepareCheckoutViewModel(strongViewController.checkoutViewModel.selectedArticleUnit,
+                checkoutViewModel: strongViewController.checkoutViewModel) { result in
+                    strongViewController.hideLoader()
                     switch result {
                     case .failure(let error):
-                        self.viewController.dismissViewControllerAnimated(true) {
-                            self.viewController.userMessage.show(error: error)
+                        strongViewController.dismissViewControllerAnimated(true) {
+                            strongViewController.userMessage.show(error: error)
                         }
                     case .success(var checkoutViewModel):
-                        checkoutViewModel.customer = self.viewController.checkoutViewModel.customer
-                        self.viewController.checkoutViewModel = checkoutViewModel
-                        self.viewController.rootStackView.configureData(self.viewController)
-                        self.viewController.refreshViewData()
+                        checkoutViewModel.customer = strongViewController.checkoutViewModel.customer
+                        strongViewController.checkoutViewModel = checkoutViewModel
+                        strongViewController.rootStackView.configureData(strongViewController)
+                        strongViewController.refreshViewData()
                     }
 
             }

--- a/AtlasUI/AtlasUI/CheckoutSummaryActionsHandler.swift
+++ b/AtlasUI/AtlasUI/CheckoutSummaryActionsHandler.swift
@@ -112,8 +112,8 @@ extension CheckoutSummaryActionsHandler {
         guard Atlas.isUserLoggedIn() else { return loadCustomerData() }
         guard let paymentURL = strongViewController.checkoutViewModel.checkout?.payment.selectionPageUrl else { return }
 
-        let paymentSelectionstrongViewController = PaymentSelectionViewController(paymentSelectionURL: paymentURL)
-        paymentSelectionstrongViewController.paymentCompletion = { result in
+        let paymentSelectionViewController = PaymentSelectionViewController(paymentSelectionURL: paymentURL)
+        paymentSelectionViewController.paymentCompletion = { result in
             switch result {
             case .success:
                 self.loadCustomerData()
@@ -121,26 +121,26 @@ extension CheckoutSummaryActionsHandler {
                 strongViewController.userMessage.show(error: error)
             }
         }
-        strongViewController.showViewController(paymentSelectionstrongViewController, sender: strongViewController)
+        strongViewController.showViewController(paymentSelectionViewController, sender: strongViewController)
     }
 
     internal func showShippingAddressSelectionScreen() {
         guard let strongViewController = self.viewController else { return }
         guard Atlas.isUserLoggedIn() else { return loadCustomerData() }
-        let addressSelectionstrongViewController = AddressPickerViewController(checkout: strongViewController.checkout,
+        let addressSelectionViewController = AddressPickerViewController(checkout: strongViewController.checkout,
             addressType: .shipping, addressSelectionCompletion: pickedAddressCompletion)
-        addressSelectionstrongViewController.selectedAddress = strongViewController.checkoutViewModel.selectedShippingAddress
-        strongViewController.showViewController(addressSelectionstrongViewController, sender: strongViewController)
+        addressSelectionViewController.selectedAddress = strongViewController.checkoutViewModel.selectedShippingAddress
+        strongViewController.showViewController(addressSelectionViewController, sender: strongViewController)
     }
 
     internal func showBillingAddressSelectionScreen() {
         guard let strongViewController = self.viewController else { return }
         guard Atlas.isUserLoggedIn() else { return loadCustomerData() }
-        let addressSelectionstrongViewController = AddressPickerViewController(checkout: strongViewController.checkout,
+        let addressSelectionViewController = AddressPickerViewController(checkout: strongViewController.checkout,
                                                                                addressType: .billing,
                                                                                addressSelectionCompletion: pickedAddressCompletion)
-        addressSelectionstrongViewController.selectedAddress = strongViewController.checkoutViewModel.selectedBillingAddress
-        strongViewController.showViewController(addressSelectionstrongViewController, sender: strongViewController)
+        addressSelectionViewController.selectedAddress = strongViewController.checkoutViewModel.selectedBillingAddress
+        strongViewController.showViewController(addressSelectionViewController, sender: strongViewController)
     }
 
     internal func handleOrderConfirmation(order: Order) {
@@ -151,8 +151,8 @@ extension CheckoutSummaryActionsHandler {
             return
         }
 
-        let paymentSelectionstrongViewController = PaymentSelectionViewController(paymentSelectionURL: paymentURL)
-        paymentSelectionstrongViewController.paymentCompletion = { result in
+        let paymentSelectionViewController = PaymentSelectionViewController(paymentSelectionURL: paymentURL)
+        paymentSelectionViewController.paymentCompletion = { result in
             switch result {
             case .success:
                 strongViewController.viewState = .OrderPlaced
@@ -160,7 +160,7 @@ extension CheckoutSummaryActionsHandler {
                 strongViewController.userMessage.show(error: error)
             }
         }
-        strongViewController.showViewController(paymentSelectionstrongViewController, sender: strongViewController)
+        strongViewController.showViewController(paymentSelectionViewController, sender: strongViewController)
     }
 
 }

--- a/AtlasUI/AtlasUITests/EditAddressTypeSpec.swift
+++ b/AtlasUI/AtlasUITests/EditAddressTypeSpec.swift
@@ -15,16 +15,16 @@ class EditAddressTypeSpec: QuickSpec {
 
         describe("Edit Address") {
             it("should format field title") {
-                expect(AddressFormField.Title.title(localizer)).to(equal("Title"))
-                expect(AddressFormField.FirstName.title(localizer)).to(equal("First Name"))
-                expect(AddressFormField.LastName.title(localizer)).to(equal("Last Name"))
-                expect(AddressFormField.Street.title(localizer)).to(equal("Street"))
+                expect(AddressFormField.Title.title(localizer)).to(equal("Title*"))
+                expect(AddressFormField.FirstName.title(localizer)).to(equal("First Name*"))
+                expect(AddressFormField.LastName.title(localizer)).to(equal("Last Name*"))
+                expect(AddressFormField.Street.title(localizer)).to(equal("Street*"))
                 expect(AddressFormField.Additional.title(localizer)).to(equal("Additional"))
-                expect(AddressFormField.Packstation.title(localizer)).to(equal("Packstation"))
-                expect(AddressFormField.MemberID.title(localizer)).to(equal("Member ID"))
-                expect(AddressFormField.Zipcode.title(localizer)).to(equal("Zipcode"))
-                expect(AddressFormField.City.title(localizer)).to(equal("City"))
-                expect(AddressFormField.Country.title(localizer)).to(equal("Country"))
+                expect(AddressFormField.Packstation.title(localizer)).to(equal("Packstation*"))
+                expect(AddressFormField.MemberID.title(localizer)).to(equal("Member ID*"))
+                expect(AddressFormField.Zipcode.title(localizer)).to(equal("Zipcode*"))
+                expect(AddressFormField.City.title(localizer)).to(equal("City*"))
+                expect(AddressFormField.Country.title(localizer)).to(equal("Country*"))
             }
 
             it("should set view model data") {

--- a/AtlasUI/AtlasUITests/EditAddressTypeSpec.swift
+++ b/AtlasUI/AtlasUITests/EditAddressTypeSpec.swift
@@ -15,16 +15,16 @@ class EditAddressTypeSpec: QuickSpec {
 
         describe("Edit Address") {
             it("should format field title") {
-                expect(AddressFormField.Title.title(localizer)).to(equal("Title*"))
-                expect(AddressFormField.FirstName.title(localizer)).to(equal("First Name*"))
-                expect(AddressFormField.LastName.title(localizer)).to(equal("Last Name*"))
-                expect(AddressFormField.Street.title(localizer)).to(equal("Street*"))
+                expect(AddressFormField.Title.title(localizer)).to(equal("Title"))
+                expect(AddressFormField.FirstName.title(localizer)).to(equal("First Name"))
+                expect(AddressFormField.LastName.title(localizer)).to(equal("Last Name"))
+                expect(AddressFormField.Street.title(localizer)).to(equal("Street"))
                 expect(AddressFormField.Additional.title(localizer)).to(equal("Additional"))
-                expect(AddressFormField.Packstation.title(localizer)).to(equal("Packstation*"))
-                expect(AddressFormField.MemberID.title(localizer)).to(equal("Member ID*"))
-                expect(AddressFormField.Zipcode.title(localizer)).to(equal("Zipcode*"))
-                expect(AddressFormField.City.title(localizer)).to(equal("City*"))
-                expect(AddressFormField.Country.title(localizer)).to(equal("Country*"))
+                expect(AddressFormField.Packstation.title(localizer)).to(equal("Packstation"))
+                expect(AddressFormField.MemberID.title(localizer)).to(equal("Member ID"))
+                expect(AddressFormField.Zipcode.title(localizer)).to(equal("Zipcode"))
+                expect(AddressFormField.City.title(localizer)).to(equal("City"))
+                expect(AddressFormField.Country.title(localizer)).to(equal("Country"))
             }
 
             it("should set view model data") {


### PR DESCRIPTION
#270: during the checkout creation request a user might cancel Checkout Summary which causes self.viewController to be nil. That is why after the successful request we get `_swift_abortRetainUnowned` crash. 