### PR TITLE
#312: Get rid of tens of billing/shipping id calls

### DIFF
--- a/AtlasSDK/AtlasSDK/APIClient_public.swift
+++ b/AtlasSDK/AtlasSDK/APIClient_public.swift
@@ -71,7 +71,7 @@ extension APIClient {
         fetch(from: endpoint, completion: completion)
     }
 
-    public func createCheckout(forArticleUnit selectedArticleUnit: SelectedArticleUnit,
+    public func createCheckout(for selectedArticleUnit: SelectedArticleUnit,
         addresses: CheckoutAddresses? = nil, completion: CheckoutCompletion) {
             let articleSKU = selectedArticleUnit.article.units[selectedArticleUnit.selectedUnitIndex].id
             let cartItemRequest = CartItemRequest(sku: articleSKU, quantity: 1)

--- a/AtlasSDK/AtlasSDK/APIClient_public.swift
+++ b/AtlasSDK/AtlasSDK/APIClient_public.swift
@@ -71,8 +71,8 @@ extension APIClient {
         fetch(from: endpoint, completion: completion)
     }
 
-    public func createCheckout(withSelectedArticleUnit selectedArticleUnit: SelectedArticleUnit,
-        billingAddressId: String? = nil, shippingAddressId: String? = nil, completion: CheckoutCompletion) {
+    public func createCheckout(forArticleUnit selectedArticleUnit: SelectedArticleUnit,
+        addresses: CheckoutAddresses? = nil, completion: CheckoutCompletion) {
             let articleSKU = selectedArticleUnit.article.units[selectedArticleUnit.selectedUnitIndex].id
             let cartItemRequest = CartItemRequest(sku: articleSKU, quantity: 1)
 
@@ -88,16 +88,15 @@ extension APIClient {
                             completion(.failure(error))
 
                         case .success(let addressList):
-                            self.createCheckout(cart.id, billingAddressId: billingAddressId,
-                                shippingAddressId: shippingAddressId) { checkoutResult in
-                                    switch checkoutResult {
-                                    case .failure(let error):
-                                        let checkoutError = AtlasAPIError.checkoutFailed(addresses: addressList,
-                                            cartId: cart.id, error: error)
-                                        completion(.failure(checkoutError))
-                                    case .success(let checkout):
-                                        completion(.success(checkout))
-                                    }
+                            self.createCheckout(cart.id, addresses: addresses) { checkoutResult in
+                                switch checkoutResult {
+                                case .failure(let error):
+                                    let checkoutError = AtlasAPIError.checkoutFailed(addresses: addressList,
+                                        cartId: cart.id, error: error)
+                                    completion(.failure(checkoutError))
+                                case .success(let checkout):
+                                    completion(.success(checkout))
+                                }
                             }
                         }
                     }
@@ -105,14 +104,11 @@ extension APIClient {
             }
     }
 
-    public func createCheckout(cartId: String, billingAddressId: String? = nil,
-        shippingAddressId: String? = nil, completion: CheckoutCompletion) {
-            let parameters = CreateCheckoutRequest(cartId: cartId,
-                billingAddressId: billingAddressId,
-                shippingAddressId: shippingAddressId).toJSON()
-            let endpoint = CreateCheckoutEndpoint(serviceURL: config.checkoutURL, parameters: parameters)
+    public func createCheckout(cartId: String, addresses: CheckoutAddresses? = nil, completion: CheckoutCompletion) {
+        let parameters = CreateCheckoutRequest(cartId: cartId, addresses: addresses).toJSON()
+        let endpoint = CreateCheckoutEndpoint(serviceURL: config.checkoutURL, parameters: parameters)
 
-            fetch(from: endpoint, completion: completion)
+        fetch(from: endpoint, completion: completion)
     }
 
     public func updateCheckout(checkoutId: String, updateCheckoutRequest: UpdateCheckoutRequest, completion: CheckoutCompletion) {

--- a/AtlasSDK/AtlasSDK/Models/CreateCheckoutRequest.swift
+++ b/AtlasSDK/AtlasSDK/Models/CreateCheckoutRequest.swift
@@ -10,10 +10,10 @@ public struct CreateCheckoutRequest: JSONRepresentable {
     public let billingAddressId: String?
     public let shippingAddressId: String?
 
-    public init(cartId: String, billingAddressId: String?, shippingAddressId: String?) {
+    public init(cartId: String, addresses: CheckoutAddresses? = nil) {
         self.cartId = cartId
-        self.billingAddressId = billingAddressId
-        self.shippingAddressId = shippingAddressId
+        self.billingAddressId = addresses?.billingAddress?.id
+        self.shippingAddressId = addresses?.shippingAddress?.id
     }
 
     public func toJSON() -> [String: AnyObject] {

--- a/AtlasSDK/AtlasSDK/Models/FormattableAddress.swift
+++ b/AtlasSDK/AtlasSDK/Models/FormattableAddress.swift
@@ -17,9 +17,15 @@ public protocol FormattableAddress: StreetAddress {
 }
 
 public protocol EquatableAddress: FormattableAddress {
+
     var id: String { get }
+
 }
 
 public func == (lhs: EquatableAddress, rhs: EquatableAddress) -> Bool {
+
     return lhs.id == rhs.id
+
 }
+
+public typealias CheckoutAddresses = (billingAddress: EquatableAddress?, shippingAddress: EquatableAddress?)

--- a/AtlasSDK/AtlasSDKTests/APICreateCheckoutSpec.swift
+++ b/AtlasSDK/AtlasSDKTests/APICreateCheckoutSpec.swift
@@ -25,7 +25,7 @@ class APICreateCheckoutSpec: APIClientBaseSpec {
                             fail(String(error))
                         case .success(let article):
                             let selectedArticleUnit = SelectedArticleUnit(article: article, selectedUnitIndex: 0)
-                            client.createCheckout(withSelectedArticleUnit: selectedArticleUnit) { result in
+                            client.createCheckout(for: selectedArticleUnit) { result in
                                 switch result {
                                 case .failure(let error):
                                     fail(String(error))

--- a/AtlasUI/AtlasUI/AddressListTableViewDelegate.swift
+++ b/AtlasUI/AtlasUI/AddressListTableViewDelegate.swift
@@ -101,7 +101,7 @@ extension AddressListTableViewDelegate: UITableViewDelegate {
             updateAddressHandler?(address: addresses[indexPath.item])
         } else {
             selectedAddress = addresses[indexPath.item]
-            self.selectionCompletion(pickedAddress: addresses[indexPath.item], pickedAddressType: self.addressType, popBackToSummaryOnFinish: true)
+            self.selectionCompletion(pickedAddress: selectedAddress, pickedAddressType: self.addressType, popBackToSummaryOnFinish: true)
             tableView.reloadData()
         }
     }

--- a/AtlasUI/AtlasUI/AddressListTableViewDelegate.swift
+++ b/AtlasUI/AtlasUI/AddressListTableViewDelegate.swift
@@ -102,8 +102,6 @@ extension AddressListTableViewDelegate: UITableViewDelegate {
         } else {
             selectedAddress = addresses[indexPath.item]
             self.selectionCompletion(pickedAddress: selectedAddress, pickedAddressType: self.addressType, popBackToSummaryOnFinish: true)
-                pickedAddressType: self.addressType,
-                popBackToSummaryOnFinish: true)
             tableView.reloadData()
         }
     }

--- a/AtlasUI/AtlasUI/AddressPickerViewController.swift
+++ b/AtlasUI/AtlasUI/AddressPickerViewController.swift
@@ -94,12 +94,12 @@ final class AddressPickerViewController: UIViewController, CheckoutProviderType 
         checkout.client.addresses { [weak self] result in
             guard let strongSelf = self else { return }
             strongSelf.loaderView.hide()
-                switch result {
-                case .failure(let error):
-                    strongSelf.userMessage.show(error: error)
-                case .success(let addresses):
-                    strongSelf.addresses = addresses
-                }
+            switch result {
+            case .failure(let error):
+                strongSelf.userMessage.show(error: error)
+            case .success(let addresses):
+                strongSelf.addresses = addresses
+            }
         }
     }
 
@@ -154,7 +154,9 @@ extension AddressPickerViewController {
     private func showCreateAddress(addressType: AddressFormType) {
         showCreateAddressViewController(addressType) { [weak self] address in
             guard let strongSelf = self else { return }
-            strongSelf.selectionCompletion(pickedAddress: address, pickedAddressType: strongSelf.addressType, popBackToSummaryOnFinish: true)
+            strongSelf.selectionCompletion(pickedAddress: address,
+                pickedAddressType: strongSelf.addressType,
+                popBackToSummaryOnFinish: true)
             strongSelf.navigationController?.popViewControllerAnimated(false)
         }
     }

--- a/AtlasUI/AtlasUI/AtlasCheckout.swift
+++ b/AtlasUI/AtlasUI/AtlasCheckout.swift
@@ -56,20 +56,22 @@ public class AtlasCheckout: LocalizerProviderType {
         viewController.presentViewController(navigationController, animated: true, completion: nil)
     }
 
-    func createCheckout(fromModel checkoutViewModel: CheckoutViewModel,
+    func createCheckoutViewModel(from checkoutViewModel: CheckoutViewModel,
         completion: CreateCheckoutViewModelCompletion) {
-            createCheckout(forArticleUnit: checkoutViewModel.selectedArticleUnit,
+            createCheckoutViewModel(for: checkoutViewModel.selectedArticleUnit,
                 addresses: checkoutViewModel.selectedAddresses, completion: completion)
     }
 
-    func createCheckout(forArticleUnit selectedArticleUnit: SelectedArticleUnit, addresses: CheckoutAddresses? = nil,
+    func createCheckoutViewModel(for selectedArticleUnit: SelectedArticleUnit, addresses: CheckoutAddresses? = nil,
         completion: CreateCheckoutViewModelCompletion) {
-            client.createCheckout(forArticleUnit: selectedArticleUnit, addresses: addresses) { checkoutResult in
+            client.createCheckout(for: selectedArticleUnit, addresses: addresses) { checkoutResult in
                 switch checkoutResult {
                 case .failure(let error):
                     if case let AtlasAPIError.checkoutFailed(_, cartId, _) = error {
-                        let checkoutModel = CheckoutViewModel(selectedArticleUnit: selectedArticleUnit, cartId: cartId, checkout: nil)
+                        let checkoutModel = CheckoutViewModel(selectedArticleUnit: selectedArticleUnit, cartId: cartId)
                         completion(.success(checkoutModel))
+                    } else {
+                        completion(.failure(error))
                     }
 
                 case .success(let checkout):

--- a/AtlasUI/AtlasUI/AtlasCheckout.swift
+++ b/AtlasUI/AtlasUI/AtlasCheckout.swift
@@ -56,22 +56,26 @@ public class AtlasCheckout: LocalizerProviderType {
         viewController.presentViewController(navigationController, animated: true, completion: nil)
     }
 
-    func prepareCheckoutViewModel(selectedArticleUnit: SelectedArticleUnit, checkoutViewModel: CheckoutViewModel? = nil,
+    func createCheckout(fromModel checkoutViewModel: CheckoutViewModel,
         completion: CreateCheckoutViewModelCompletion) {
-            client.createCheckout(withSelectedArticleUnit: selectedArticleUnit,
-                billingAddressId: checkoutViewModel?.selectedBillingAddress?.id,
-                shippingAddressId: checkoutViewModel?.selectedShippingAddress?.id) { checkoutResult in
-                    switch checkoutResult {
-                    case .failure(let error):
-                        if case let AtlasAPIError.checkoutFailed(_, cartId, _) = error {
-                            let checkoutModel = CheckoutViewModel(selectedArticleUnit: selectedArticleUnit, cartId: cartId, checkout: nil)
-                            completion(.success(checkoutModel))
-                        }
+            createCheckout(forArticleUnit: checkoutViewModel.selectedArticleUnit,
+                addresses: checkoutViewModel.selectedAddresses, completion: completion)
+    }
 
-                    case .success(let checkout):
-                        let checkoutModel = CheckoutViewModel(selectedArticleUnit: selectedArticleUnit, checkout: checkout)
+    func createCheckout(forArticleUnit selectedArticleUnit: SelectedArticleUnit, addresses: CheckoutAddresses? = nil,
+        completion: CreateCheckoutViewModelCompletion) {
+            client.createCheckout(forArticleUnit: selectedArticleUnit, addresses: addresses) { checkoutResult in
+                switch checkoutResult {
+                case .failure(let error):
+                    if case let AtlasAPIError.checkoutFailed(_, cartId, _) = error {
+                        let checkoutModel = CheckoutViewModel(selectedArticleUnit: selectedArticleUnit, cartId: cartId, checkout: nil)
                         completion(.success(checkoutModel))
                     }
+
+                case .success(let checkout):
+                    let checkoutModel = CheckoutViewModel(selectedArticleUnit: selectedArticleUnit, checkout: checkout)
+                    completion(.success(checkoutModel))
+                }
             }
     }
 

--- a/AtlasUI/AtlasUI/CheckoutSummaryActionsHandler.swift
+++ b/AtlasUI/AtlasUI/CheckoutSummaryActionsHandler.swift
@@ -73,7 +73,7 @@ extension CheckoutSummaryActionsHandler {
 
             switch result {
             case .failure(let error):
-                    strongViewController.userMessage.show(error: error)
+                strongViewController.userMessage.show(error: error)
             case .success(let customer):
                 self.generateCheckout(customer)
             }
@@ -85,19 +85,18 @@ extension CheckoutSummaryActionsHandler {
         guard let strongViewController = self.viewController else { return }
 
         strongViewController.showLoader()
-        strongViewController.checkout.prepareCheckoutViewModel(strongViewController.checkoutViewModel.selectedArticleUnit,
-            checkoutViewModel: strongViewController.checkoutViewModel) { result in
-                strongViewController.hideLoader()
-                switch result {
-                case .failure(let error):
-                    strongViewController.dismissViewControllerAnimated(true) {
-                        strongViewController.userMessage.show(error: error)
-                    }
-                case .success(var checkoutViewModel):
-                    checkoutViewModel.customer = customer
-                    strongViewController.checkoutViewModel = checkoutViewModel
-                    strongViewController.viewState = checkoutViewModel.checkoutViewState
+        strongViewController.checkout.createCheckout(fromModel: strongViewController.checkoutViewModel) { result in
+            strongViewController.hideLoader()
+            switch result {
+            case .failure(let error):
+                strongViewController.dismissViewControllerAnimated(true) {
+                    strongViewController.userMessage.show(error: error)
                 }
+            case .success(var checkoutViewModel):
+                checkoutViewModel.customer = customer
+                strongViewController.checkoutViewModel = checkoutViewModel
+                strongViewController.viewState = checkoutViewModel.checkoutViewState
+            }
         }
     }
 
@@ -190,20 +189,19 @@ extension CheckoutSummaryActionsHandler {
 
             strongViewController.showLoader()
 
-            strongViewController.checkout.prepareCheckoutViewModel(strongViewController.checkoutViewModel.selectedArticleUnit,
-                checkoutViewModel: strongViewController.checkoutViewModel) { result in
-                    strongViewController.hideLoader()
-                    switch result {
-                    case .failure(let error):
-                        strongViewController.dismissViewControllerAnimated(true) {
-                            strongViewController.userMessage.show(error: error)
-                        }
-                    case .success(var checkoutViewModel):
-                        checkoutViewModel.customer = strongViewController.checkoutViewModel.customer
-                        strongViewController.checkoutViewModel = checkoutViewModel
-                        strongViewController.rootStackView.configureData(strongViewController)
-                        strongViewController.refreshViewData()
+            strongViewController.checkout.createCheckout(fromModel: strongViewController.checkoutViewModel) { result in
+                strongViewController.hideLoader()
+                switch result {
+                case .failure(let error):
+                    strongViewController.dismissViewControllerAnimated(true) {
+                        strongViewController.userMessage.show(error: error)
                     }
+                case .success(var checkoutViewModel):
+                    checkoutViewModel.customer = strongViewController.checkoutViewModel.customer
+                    strongViewController.checkoutViewModel = checkoutViewModel
+                    strongViewController.rootStackView.configureData(strongViewController)
+                    strongViewController.refreshViewData()
+                }
             }
     }
 }

--- a/AtlasUI/AtlasUI/CheckoutSummaryActionsHandler.swift
+++ b/AtlasUI/AtlasUI/CheckoutSummaryActionsHandler.swift
@@ -85,7 +85,7 @@ extension CheckoutSummaryActionsHandler {
         guard let strongViewController = self.viewController else { return }
 
         strongViewController.showLoader()
-        strongViewController.checkout.createCheckout(fromModel: strongViewController.checkoutViewModel) { result in
+        strongViewController.checkout.createCheckoutViewModel(from: strongViewController.checkoutViewModel) { result in
             strongViewController.hideLoader()
             switch result {
             case .failure(let error):
@@ -189,7 +189,7 @@ extension CheckoutSummaryActionsHandler {
 
             strongViewController.showLoader()
 
-            strongViewController.checkout.createCheckout(fromModel: strongViewController.checkoutViewModel) { result in
+            strongViewController.checkout.createCheckoutViewModel(from: strongViewController.checkoutViewModel) { result in
                 strongViewController.hideLoader()
                 switch result {
                 case .failure(let error):

--- a/AtlasUI/AtlasUI/CheckoutSummaryViewController.swift
+++ b/AtlasUI/AtlasUI/CheckoutSummaryViewController.swift
@@ -158,12 +158,4 @@ extension CheckoutSummaryViewController {
         }
     }
 
-    func createCheckout(cartId: String, completion: CheckoutCompletion) {
-        checkout.client.createCheckout(cartId,
-            billingAddressId: checkoutViewModel.selectedBillingAddress?.id,
-            shippingAddressId: checkoutViewModel.selectedShippingAddress?.id) { checkout in
-                completion(checkout)
-        }
-    }
-
 }

--- a/AtlasUI/AtlasUI/CheckoutViewModel.swift
+++ b/AtlasUI/AtlasUI/CheckoutViewModel.swift
@@ -16,6 +16,10 @@ struct CheckoutViewModel {
     var selectedBillingAddress: EquatableAddress?
     var selectedShippingAddress: EquatableAddress?
 
+    var selectedAddresses: CheckoutAddresses {
+        return (billingAddress: selectedBillingAddress, shippingAddress: selectedShippingAddress)
+    }
+
     init(selectedArticleUnit: SelectedArticleUnit,
         shippingPrice: Article.Price? = nil,
         cartId: String? = nil,

--- a/AtlasUI/AtlasUI/SizeListSelectionViewController.swift
+++ b/AtlasUI/AtlasUI/SizeListSelectionViewController.swift
@@ -105,7 +105,7 @@ extension SizeListSelectionViewController: UITableViewDelegate {
 
             case .success(let customer):
                 let selectedArticleUnit = SelectedArticleUnit(article: self.article, selectedUnitIndex: indexPath.row)
-                self.checkout.prepareCheckoutViewModel(selectedArticleUnit) { result in
+                self.checkout.createCheckoutViewModel(for: selectedArticleUnit) { result in
                     self.loaderView.hide()
                     switch result {
                     case .failure(let error):

--- a/AtlasUI/AtlasUI/SizeListSelectionViewController.swift
+++ b/AtlasUI/AtlasUI/SizeListSelectionViewController.swift
@@ -79,7 +79,7 @@ final class SizeListSelectionViewController: UITableViewController, CheckoutProv
             case .success(let customer):
                 let selectedArticleUnit = SelectedArticleUnit(article: self.article,
                     selectedUnitIndex: indexPath.row)
-                self.checkout.prepareCheckoutViewModel(selectedArticleUnit) { result in
+                self.checkout.createCheckout(forArticleUnit: selectedArticleUnit) { result in
                     spinner.stopAnimating()
                     switch result {
                     case .failure(let error):

--- a/AtlasUI/AtlasUI/SizeSelectionViewController.swift
+++ b/AtlasUI/AtlasUI/SizeSelectionViewController.swift
@@ -60,7 +60,7 @@ final class SizeSelectionViewController: UIViewController, CheckoutProviderType 
     private func generateCheckout(withArticle article: Article, customer: Customer) {
         let selectedArticleUnit = SelectedArticleUnit(article: article, selectedUnitIndex: 0)
 
-        checkout.createCheckout(forArticleUnit: selectedArticleUnit) { result in
+        checkout.createCheckoutViewModel(for: selectedArticleUnit) { result in
             switch result {
             case .failure(let error):
                 self.dismissViewControllerAnimated(true) {
@@ -101,8 +101,8 @@ final class SizeSelectionViewController: UIViewController, CheckoutProviderType 
         guard !article.hasSingleUnit else {
             return showCheckoutScreen(article, selectedUnitIndex: 0)
         }
-            self.activityIndicatorView.stopAnimating()
-            self.showSizeListViewController(article)
+        self.activityIndicatorView.stopAnimating()
+        self.showSizeListViewController(article)
     }
 
     private func showSizeListViewController(article: Article) {

--- a/AtlasUI/AtlasUI/SizeSelectionViewController.swift
+++ b/AtlasUI/AtlasUI/SizeSelectionViewController.swift
@@ -60,7 +60,7 @@ final class SizeSelectionViewController: UIViewController, CheckoutProviderType 
     private func generateCheckout(withArticle article: Article, customer: Customer) {
         let selectedArticleUnit = SelectedArticleUnit(article: article, selectedUnitIndex: 0)
 
-        checkout.prepareCheckoutViewModel(selectedArticleUnit) { result in
+        checkout.createCheckout(forArticleUnit: selectedArticleUnit) { result in
             switch result {
             case .failure(let error):
                 self.dismissViewControllerAnimated(true) {


### PR DESCRIPTION
I know it might be better to use simple string ids at least in lowest call in APIClient, but I think devs would work with existing addresses anyway.