### PR TITLE
#531: Sales Channel

### DIFF
--- a/AtlasDemo/AtlasDemo.xcodeproj/xcshareddata/xcschemes/AtlasDemo.xcscheme
+++ b/AtlasDemo/AtlasDemo.xcodeproj/xcshareddata/xcschemes/AtlasDemo.xcscheme
@@ -109,7 +109,7 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "USE_MOCK_API"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "PRINT_REQUEST_DESCRIPTION"

--- a/AtlasSDK/AtlasSDK/APIClient_public.swift
+++ b/AtlasSDK/AtlasSDK/APIClient_public.swift
@@ -57,7 +57,8 @@ public typealias CheckAddressCompletion = AtlasResult<CheckAddressResponse> -> V
 extension APIClient {
 
     public func customer(completion: CustomerCompletion) {
-        let endpoint = GetCustomerEndpoint(serviceURL: config.checkoutURL)
+        let endpoint = GetCustomerEndpoint(serviceURL: config.checkoutURL,
+                                           salesChannel: config.salesChannel.identifier)
         fetch(from: endpoint, completion: completion)
     }
 
@@ -104,13 +105,15 @@ extension APIClient {
     public func createCheckout(cartId: String, addresses: CheckoutAddresses? = nil, completion: CheckoutCompletion) {
         let parameters = CreateCheckoutRequest(cartId: cartId, addresses: addresses).toJSON()
         let endpoint = CreateCheckoutEndpoint(serviceURL: config.checkoutURL,
-                                              parameters: parameters)
+                                              parameters: parameters,
+                                              salesChannel: config.salesChannel.identifier)
         fetch(from: endpoint, completion: completion)
     }
 
     public func updateCheckout(checkoutId: String, updateCheckoutRequest: UpdateCheckoutRequest, completion: CheckoutCompletion) {
         let endpoint = UpdateCheckoutEndpoint(serviceURL: config.checkoutURL,
                                               parameters: updateCheckoutRequest.toJSON(),
+                                              salesChannel: config.salesChannel.identifier,
                                               checkoutId: checkoutId)
         fetch(from: endpoint, completion: completion)
     }
@@ -119,6 +122,7 @@ extension APIClient {
         let parameters = OrderRequest(checkoutId: checkoutId).toJSON()
         let endpoint = CreateOrderEndpoint(serviceURL: config.checkoutURL,
                                            parameters: parameters,
+                                           salesChannel: config.salesChannel.identifier,
                                            checkoutId: checkoutId)
         fetch(from: endpoint, completion: completion)
     }
@@ -170,7 +174,8 @@ extension APIClient {
 
     public func checkAddress(request: CheckAddressRequest, completion: CheckAddressCompletion) {
         let endpoint = CheckAddressEndpoint(serviceURL: config.checkoutURL,
-                                            checkAddressRequest: request)
+                                            checkAddressRequest: request,
+                                            salesChannel: config.salesChannel.identifier)
         fetch(from: endpoint, completion: completion)
     }
 

--- a/AtlasSDK/AtlasSDK/APIClient_public.swift
+++ b/AtlasSDK/AtlasSDK/APIClient_public.swift
@@ -62,8 +62,10 @@ extension APIClient {
     }
 
     public func createCart(cartItemRequests: CartItemRequest..., completion: CartCompletion) {
-        let parameters = CartRequest(salesChannel: config.salesChannel.identifier, items: cartItemRequests, replaceItems: true).toJSON()
-        let endpoint = CreateCartEndpoint(serviceURL: config.checkoutURL, parameters: parameters)
+        let parameters = CartRequest(items: cartItemRequests, replaceItems: true).toJSON()
+        let endpoint = CreateCartEndpoint(serviceURL: config.checkoutURL,
+                                          parameters: parameters,
+                                          salesChannel: config.salesChannel.identifier)
         fetch(from: endpoint, completion: completion)
     }
 

--- a/AtlasSDK/AtlasSDK/Endpoints/CheckAddressEndpoint.swift
+++ b/AtlasSDK/AtlasSDK/Endpoints/CheckAddressEndpoint.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-struct CheckAddressEndpoint: ConfigurableEndpoint {
+struct CheckAddressEndpoint: ConfigurableEndpoint, SalesChannelEndpoint {
 
     let serviceURL: NSURL
     let method: HTTPMethod = .POST
@@ -17,5 +17,6 @@ struct CheckAddressEndpoint: ConfigurableEndpoint {
     }
 
     let checkAddressRequest: CheckAddressRequest
+    let salesChannel: String
 
 }

--- a/AtlasSDK/AtlasSDK/Endpoints/CreateAddressEndpoint.swift
+++ b/AtlasSDK/AtlasSDK/Endpoints/CreateAddressEndpoint.swift
@@ -11,9 +11,6 @@ struct CreateAddressEndpoint: ConfigurableEndpoint, SalesChannelEndpoint {
     var path: String { return "addresses" }
     let acceptedContentType = "application/x.zalando.customer.address.create.response+json"
     let contentType = "application/x.zalando.customer.address.create+json"
-    var queryItems: [NSURLQueryItem]? {
-        return NSURLQueryItem.build(["sales_channel": salesChannel])
-    }
 
     var parameters: [String: AnyObject]? {
         return createAddressRequest.toJSON()

--- a/AtlasSDK/AtlasSDK/Endpoints/CreateCartEndpoint.swift
+++ b/AtlasSDK/AtlasSDK/Endpoints/CreateCartEndpoint.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2016 Zalando SE. All rights reserved.
 //
 
-struct CreateCartEndpoint: ConfigurableEndpoint {
+struct CreateCartEndpoint: ConfigurableEndpoint, SalesChannelEndpoint {
 
     let serviceURL: NSURL
     let method: HTTPMethod = .POST
@@ -10,5 +10,6 @@ struct CreateCartEndpoint: ConfigurableEndpoint {
     let contentType = "application/x.zalando.cart.create+json"
     let acceptedContentType = "application/x.zalando.cart.create.response+json"
     let parameters: [String: AnyObject]?
+    let salesChannel: String
 
 }

--- a/AtlasSDK/AtlasSDK/Endpoints/CreateCheckoutEndpoint.swift
+++ b/AtlasSDK/AtlasSDK/Endpoints/CreateCheckoutEndpoint.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2016 Zalando SE. All rights reserved.
 //
 
-struct CreateCheckoutEndpoint: ConfigurableEndpoint {
+struct CreateCheckoutEndpoint: ConfigurableEndpoint, SalesChannelEndpoint {
 
     let serviceURL: NSURL
     let method: HTTPMethod = .POST
@@ -10,5 +10,6 @@ struct CreateCheckoutEndpoint: ConfigurableEndpoint {
     let contentType = "application/x.zalando.customer.checkout.create+json"
     let acceptedContentType = "application/x.zalando.customer.checkout.create.response+json"
     let parameters: [String: AnyObject]?
+    let salesChannel: String
 
 }

--- a/AtlasSDK/AtlasSDK/Endpoints/CreateOrderEndpoint.swift
+++ b/AtlasSDK/AtlasSDK/Endpoints/CreateOrderEndpoint.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2016 Zalando SE. All rights reserved.
 //
 
-struct CreateOrderEndpoint: ConfigurableEndpoint {
+struct CreateOrderEndpoint: ConfigurableEndpoint, SalesChannelEndpoint {
 
     let serviceURL: NSURL
     let method: HTTPMethod = .POST
@@ -10,6 +10,7 @@ struct CreateOrderEndpoint: ConfigurableEndpoint {
     let contentType = "application/x.zalando.customer.order.create+json"
     let acceptedContentType = "application/x.zalando.customer.order.create.response+json"
     let parameters: [String: AnyObject]?
+    let salesChannel: String
 
     let checkoutId: String
 

--- a/AtlasSDK/AtlasSDK/Endpoints/DeleteAddressEndpoint.swift
+++ b/AtlasSDK/AtlasSDK/Endpoints/DeleteAddressEndpoint.swift
@@ -9,7 +9,7 @@ struct DeleteAddressEndpoint: ConfigurableEndpoint, SalesChannelEndpoint {
     var path: String { return "addresses/\(addressId)" }
     let acceptedContentType = "application/x.zalando.customer.addresses+json"
     var queryItems: [NSURLQueryItem]? {
-        return NSURLQueryItem.build(["sales_channel": salesChannel, "address_id": addressId])
+        return NSURLQueryItem.build(["address_id": addressId])
     }
 
     let addressId: String

--- a/AtlasSDK/AtlasSDK/Endpoints/GetAddressesEndpoint.swift
+++ b/AtlasSDK/AtlasSDK/Endpoints/GetAddressesEndpoint.swift
@@ -7,9 +7,6 @@ struct GetAddressesEndpoint: ConfigurableEndpoint, SalesChannelEndpoint {
     let serviceURL: NSURL
     let path = "addresses"
     let acceptedContentType = "application/x.zalando.customer.addresses+json"
-    var queryItems: [NSURLQueryItem]? {
-        return NSURLQueryItem.build(["sales_channel": salesChannel])
-    }
 
     let salesChannel: String
 

--- a/AtlasSDK/AtlasSDK/Endpoints/GetArticlesEndpoint.swift
+++ b/AtlasSDK/AtlasSDK/Endpoints/GetArticlesEndpoint.swift
@@ -10,7 +10,6 @@ struct GetArticleEndpoint: ConfigurableEndpoint, SalesChannelEndpoint {
     let sku: String
     var queryItems: [NSURLQueryItem]? {
         return NSURLQueryItem.build([
-            "sales_channel": salesChannel,
             "client_id": clientId,
             "fields": fields?.joinWithSeparator(",")
         ])

--- a/AtlasSDK/AtlasSDK/Endpoints/GetCustomerEndpoint.swift
+++ b/AtlasSDK/AtlasSDK/Endpoints/GetCustomerEndpoint.swift
@@ -2,10 +2,11 @@
 //  Copyright © 2016 Zalando SE. All rights reserved.
 //
 
-struct GetCustomerEndpoint: ConfigurableEndpoint {
+struct GetCustomerEndpoint: ConfigurableEndpoint, SalesChannelEndpoint {
 
     var serviceURL: NSURL
     let path = "customer"
     let acceptedContentType = "application/x.zalando.customer+json"
+    let salesChannel: String
 
 }

--- a/AtlasSDK/AtlasSDK/Endpoints/UpdateAddressEndpoint.swift
+++ b/AtlasSDK/AtlasSDK/Endpoints/UpdateAddressEndpoint.swift
@@ -11,9 +11,6 @@ struct UpdateAddressEndpoint: ConfigurableEndpoint, SalesChannelEndpoint {
     var path: String { return "addresses/\(addressId)" }
     let acceptedContentType = "application/x.zalando.customer.address.update.response+json"
     let contentType = "application/x.zalando.customer.address.update+json"
-    var queryItems: [NSURLQueryItem]? {
-        return NSURLQueryItem.build(["sales_channel": salesChannel])
-    }
 
     var parameters: [String: AnyObject]? {
         return updateAddressRequest.toJSON()

--- a/AtlasSDK/AtlasSDK/Endpoints/UpdateCheckoutEndpoint.swift
+++ b/AtlasSDK/AtlasSDK/Endpoints/UpdateCheckoutEndpoint.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2016 Zalando SE. All rights reserved.
 //
 
-struct UpdateCheckoutEndpoint: ConfigurableEndpoint {
+struct UpdateCheckoutEndpoint: ConfigurableEndpoint, SalesChannelEndpoint {
 
     let serviceURL: NSURL
     let method: HTTPMethod = .PUT
@@ -10,6 +10,7 @@ struct UpdateCheckoutEndpoint: ConfigurableEndpoint {
     let contentType = "application/x.zalando.customer.checkout.update+json"
     let acceptedContentType = "application/x.zalando.customer.checkout.update.response+json"
     let parameters: [String: AnyObject]?
+    let salesChannel: String
 
     let checkoutId: String
 

--- a/AtlasSDK/AtlasSDK/Models/CartRequest.swift
+++ b/AtlasSDK/AtlasSDK/Models/CartRequest.swift
@@ -6,19 +6,16 @@ import Foundation
 
 public struct CartRequest: JSONRepresentable {
 
-    public let salesChannel: String
     public let items: [CartItemRequest]
     public let replaceItems: Bool
 
-    public init(salesChannel: String, items: [CartItemRequest], replaceItems: Bool = true) {
-        self.salesChannel = salesChannel
+    public init(items: [CartItemRequest], replaceItems: Bool = true) {
         self.items = items
         self.replaceItems = replaceItems
     }
 
     public func toJSON() -> [String: AnyObject] {
         return [
-            "sales_channel": self.salesChannel,
             "replace_items": self.replaceItems,
             "items": self.items.map { $0.toJSON() }
         ]


### PR DESCRIPTION
API will be updated soon and will require the sales channels to be supplied in the header only. No more sales channels in query parameters or in body
#531 