### PR TITLE
#689: Use currencyCode instead of currencySymbol in price formatter

### DIFF
--- a/AtlasSDK.xcworkspace/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/AtlasSDK.xcworkspace/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -6,7 +6,7 @@
       <BreakpointProxy
          BreakpointExtensionID = "Xcode.Breakpoint.ExceptionBreakpoint">
          <BreakpointContent
-            shouldBeEnabled = "No"
+            shouldBeEnabled = "Yes"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             scope = "0"

--- a/AtlasUI/AtlasUI/Utils/Localizer.swift
+++ b/AtlasUI/AtlasUI/Utils/Localizer.swift
@@ -78,8 +78,8 @@ struct Localizer {
         return String(format: localizedString, arguments: formatArguments.flatMap { $0 })
     }
 
-    func format(price: NSNumber, withCurrency currencySymbol: String? = nil) -> String? {
-        priceFormatter.currencySymbol = currencySymbol
+    func format(price: NSNumber, withCurrencyCode currencyCode: String? = nil) -> String? {
+        priceFormatter.currencyCode = currencyCode
         return priceFormatter.string(from: price)
     }
 
@@ -107,12 +107,12 @@ extension Localizer {
         return shared.format(string: string, formatArguments: formatArguments)
     }
 
-    static func format(price: NSNumber, withCurrency currencySymbol: String? = nil) -> String? {
-        return shared.format(price: price, withCurrency: currencySymbol)
+    static func format(price: NSNumber, withCurrencyCode currencyCode: String? = nil) -> String? {
+        return shared.format(price: price, withCurrencyCode: currencyCode)
     }
 
     static func format(price: Money) -> String? {
-        return shared.format(price: price.amount, withCurrency: price.currency)
+        return format(price: price.amount, withCurrencyCode: price.currency)
     }
 
     static func format(date: Date) -> String? {

--- a/AtlasUI/AtlasUITests/LocalizationTests.swift
+++ b/AtlasUI/AtlasUITests/LocalizationTests.swift
@@ -47,12 +47,12 @@ class LocalizationTests: XCTestCase {
     }
 
     func testNegativeFrenchUKPriceWithOwnCurrencyFormat() {
-        expectPrice(-100, inCurrency: "KABOOM", formattedFor: "fr_UK", toBe: "-100,00\u{00a0}KABOOM")
+        expectPrice(-100, inCurrency: "KABOOM", formattedFor: "fr_UK", toBe: "-100,00\u{00a0}KAB")
     }
 
     private func expectPrice(_ price: NSNumber, inCurrency currency: String? = nil, formattedFor identifier: String, toBe expectedFormat: String) {
         let loc = try! Localizer(localeIdentifier: identifier)
-        let formattedPrice = loc.format(price: price, withCurrency: currency)
+        let formattedPrice = loc.format(price: price, withCurrencyCode: currency)
 
         expect(formattedPrice) == expectedFormat
     }


### PR DESCRIPTION
#689: Use currencyCode instead of currencySymbol in price formatter